### PR TITLE
Updated baseclient.py

### DIFF
--- a/ensembl_rest/core/baseclient.py
+++ b/ensembl_rest/core/baseclient.py
@@ -9,7 +9,7 @@ This file is part of pyEnsembl.
 
 from .restclient import RESTClient, HTTPError
 import pprint
-
+import sys
 
 class BaseEnsemblRESTClient:
     """Base client for an Ensembl REST API."""


### PR DESCRIPTION
added sys module import statement.

sys is used to raise an error on line 45, but was not imported.